### PR TITLE
remove unnecessary iput in do_exec()

### DIFF
--- a/src/kern/exec.c
+++ b/src/kern/exec.c
@@ -58,7 +58,6 @@ int do_exec(char *path, char **argv){
 
     ip = namei(path, 0);
     if (ip==NULL) {
-        iput(iput);
         return syserr(ENOENT);
     }
     // read the first block of file to get the a.out header.


### PR DESCRIPTION
If ip is NULL, iput(ip) will cause a panic.
However, "iput(iput)" is a typo.
