### PR TITLE
a typo error

### DIFF
--- a/src/kern/exec.c
+++ b/src/kern/exec.c
@@ -58,7 +58,6 @@ int do_exec(char *path, char **argv){
 
     ip = namei(path, 0);
     if (ip==NULL) {
-        iput(ip);
         return syserr(ENOENT);
     }
     // read the first block of file to get the a.out header.


### PR DESCRIPTION
iput(iput) is a typo error, 

also since ip is null, 
it's better return directly.
so remove iput(ip); 
