### PR TITLE
Delete trailing whitespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ include build/user.mk
 
 all: bochs
 
-bochs: build 
+bochs: build
 	bochs -q -f .bochsrc
 
 debug: build
 	bochs-dbg -q -f .bochsrc
 
-build: 
+build:
 	echo
 
 clean:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ static inline _SYS3(int, open, char*, int, int);
 static inline _SYS2(int, creat, char*, int);
 static inline _SYS1(int, close, int);
 static inline _SYS3(int, fcntl, int, int, int);
-static inline _SYS3(int, mknod, char*, int, int); 
+static inline _SYS3(int, mknod, char*, int, int);
 static inline _SYS3(int, write, int, char*, int);
 static inline _SYS3(int, read, int, char*, int);
 static inline _SYS3(int, lseek, int, int, int);
@@ -36,11 +36,11 @@ static inline _SYS1(int, chroot, char*);
 static inline _SYS1(int, dup, int);
 static inline _SYS2(int, dup2, int, int);
 static inline _SYS2(int, link, char*, char*);
-static inline _SYS1(int, unlink, char*); 
-static inline _SYS2(int, stat, char*, struct stat*); 
-static inline _SYS2(int, fstat, int, struct stat*); 
+static inline _SYS1(int, unlink, char*);
+static inline _SYS2(int, stat, char*, struct stat*);
+static inline _SYS2(int, fstat, int, struct stat*);
 //
-static inline _SYS0(int, fork); 
+static inline _SYS0(int, fork);
 static inline _SYS2(int, exec, char*, char**);
 static inline _SYS1(int, _exit, int);
 //

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ cinc   = '-Isrc/inc -Isrc/inc/usr'
 cflag  = %{
   -Wall
   -nostdinc -fno-builtin -fno-stack-protector
-  -finline-functions -finline-small-functions -findirect-inlining -finline-functions -finline-functions-called-once 
+  -finline-functions -finline-small-functions -findirect-inlining -finline-functions -finline-functions-called-once
 }.split(/\s/).join(' ')
 
 mkdir_p 'bin'
@@ -19,14 +19,14 @@ task :bochs => :build do
   sh "bochs -q -f .bochsrc"
 end
 
-task :nm => :build do 
+task :nm => :build do
   sh 'cat main.nmtab'
 end
 
 task :debug => :build do
   sh "bochs-dbg -q -f .bochsrc"
 end
-  
+
 task :build => ['bin/kernel.img', :rootfs, :ctags]
 
 task :clean do
@@ -40,7 +40,7 @@ task :werr do
 end
 
 ## helpers ##
-task :todo do 
+task :todo do
   sh "grep -r -n '\\(TODO\\|\\<bug\\>\\)' ./src --color"
 end
 
@@ -48,7 +48,7 @@ task :ctags do
   sh "(cd src; ctags -R .)"
 end
 
-task :fsck do 
+task :fsck do
   sh "fsck.minix -fl ./bin/rootfs.img"
 end
 
@@ -68,7 +68,7 @@ file 'bin/boot.o' => ['src/boot/boot.S'] do
   sh "nasm -f elf -o bin/boot.o src/boot/boot.S"
 end
 
-file 'bin/boot.bin' => ['bin/boot.o', 'tool/boot.ld'] do 
+file 'bin/boot.bin' => ['bin/boot.o', 'tool/boot.ld'] do
   sh "ld bin/boot.o -o bin/boot.bin -e c -T tool/boot.ld"
 end
 
@@ -109,7 +109,7 @@ file 'bin/main.elf' => ofiles + ['tool/main.ld'] do
 end
 
 # ----------------------------------------------------------------------
-# the rootfs part. 
+# the rootfs part.
 # => rootfs.img
 
 # the root file system aka the hard disk image, 1mb yet and ignored
@@ -118,7 +118,7 @@ end
 task :rootfs => ['bin/rootfs.img']
 
 # init and copy some thing into the hard disk image.
-file 'bin/rootfs.img' => [:usr] do 
+file 'bin/rootfs.img' => [:usr] do
   `rm -f bin/rootfs.img`
   sh "bximage bin/rootfs.img -hd -mode=flat -size=1 -q"
   sh "mkfs.minix bin/rootfs.img"
@@ -167,7 +167,7 @@ usr_cfiles.each do |fn_c|
   fn = File.basename(fn_c).ext('')
   fn_o = 'bin/usr/'+fn.ext('o')
   fn_e = 'bin/usr/'+fn
-  file fn_e => [fn_c, :libsys, 'tool/user.ld'] do 
+  file fn_e => [fn_c, :libsys, 'tool/user.ld'] do
     sh "gcc -c #{cinc} -nostdinc -fno-builtin -fno-stack-protector #{fn_c} -o #{fn_o}"
     sh "ld #{libsys_ofiles*' '} #{fn_o} -o #{fn_e} -e c -T tool/user.ld"
     sh "nm #{fn_e} > #{fn_o.ext('sym')}"

--- a/build/kern.mk
+++ b/build/kern.mk
@@ -6,7 +6,7 @@ S_FILES = src/kern/entry.S
 O_FILES = $(addprefix bin/, $(basename $(C_FILES:.c=.o) $(S_FILES:.S=.o)))
 
 bin/%.o: $(wildcard src/**/%.c) $(H_FILES)
-	gcc $(CFLAG) $(CINC) -o $@ -c $< 
+	gcc $(CFLAG) $(CINC) -o $@ -c $<
 
 bin/entry.o: src/kern/entry.S
 	nasm -f elf -o $@ $<

--- a/src/blk/buf.c
+++ b/src/blk/buf.c
@@ -36,11 +36,11 @@ struct buf* incore(ushort dev, uint blkno){
 /* allocate a block.
  *
  * noet: getblk *ALWAYS* returns a B_BUSY block, so the other processes
- * can not access this. so never forget brelse it after a getblk, just 
+ * can not access this. so never forget brelse it after a getblk, just
  * as malloc/free.
  * so codes like
  *      bp = bread(dev, 1);
- *      bp = bread(dev, 1); 
+ *      bp = bread(dev, 1);
  * may sleep forever.
  *
  * TODO: ignored the B_DIRTY scenary.
@@ -53,7 +53,7 @@ struct buf* getblk(int dev, uint blkno){
         panic("error devno.");
     }
 
-_loop: 
+_loop:
     if (dev < 0){
         dtp = (struct devtab*) &bfreelist;
     }
@@ -71,7 +71,7 @@ _loop:
                 sleep((uint)bp, PRIBIO);
                 sti();
                 goto _loop;
-            } 
+            }
             sti();
             notavail(bp);
             return bp;
@@ -96,7 +96,7 @@ _loop:
         bwrite(bp);
         goto _loop;
     }
-    // finally, take it from the old dev's cache list and 
+    // finally, take it from the old dev's cache list and
     cli();
     bp->b_prev->b_next = bp->b_next;
     bp->b_next->b_prev = bp->b_prev;
@@ -106,7 +106,7 @@ _loop:
     dtp->b_next->b_prev = bp;
     dtp->b_next = bp;
     sti();
-    // 
+    //
     bp->b_dev = dev;
     bp->b_blkno = blkno;
     return bp;
@@ -154,7 +154,7 @@ void iowait(struct buf *bp){
 
 void iodone(struct buf *bp){
     bp->b_flag |= B_DONE;
-    bp->b_flag &= ~B_WANTED; 
+    bp->b_flag &= ~B_WANTED;
     //brelse(bp);
     wakeup((uint)bp);
 }
@@ -169,7 +169,7 @@ void iodone(struct buf *bp){
 struct buf* bread(int dev, uint blkno){
     struct buf *bp;
     bp = getblk(dev, blkno);
-    if (bp->b_flag & B_DONE) { 
+    if (bp->b_flag & B_DONE) {
         return bp;
     }
     bp->b_flag |= B_READ;
@@ -213,7 +213,7 @@ void buf_init() {
     bfreelist.b_prev = bfreelist.b_next = &bfreelist;
     bfreelist.av_prev = bfreelist.av_next = &bfreelist;
     for(i=0; i<NBUF; i++){
-        bp = &buff[i]; 
+        bp = &buff[i];
         bp->b_dev = NODEV;
         bp->b_data = buffers[i];
         bp->b_flag = B_BUSY;

--- a/src/blk/conf.c
+++ b/src/blk/conf.c
@@ -12,7 +12,7 @@ ushort rootdev = DEVNO(1, 0);
 
 struct bdevsw   bdevsw[NBLKDEV] = {
     { 0, }, /* NODEV */
-    { &nulldev, &nulldev, &hd_request, &hdtab } 
+    { &nulldev, &nulldev, &hd_request, &hdtab }
 };
 
 struct cdevsw   cdevsw[NCHRDEV] = {

--- a/src/blk/hd.c
+++ b/src/blk/hd.c
@@ -10,22 +10,22 @@
 /*
  * hd.c - driver for the hard disk.
  * Ingore the second ide drive right now.
- * 
+ *
  * Many constants, refered from http://wiki.osdev.org/IDE.
  * Thanks buddy.
  * */
 
 struct devtab hdtab = { 0 , };
 
-/* 
+/*
  * Drive number can only be 0 or 1.
  * lba is 28-bit.
  * Number of sectors must <= 255.
  *
  * note: 0x1F6 is the register HD_DEVSEL, which (might) stands for HD DEV SELECTOR.
  * if bit 6 of this register is set, we are going to use LBA as addressing mode.
- * In LBA mode, the (8 bits) register 0x1F3,0x1f4,0x1F5 and the lower 4 bits of 0x1F6, 
- * forms a 28-bit LBA address, so called LBA-28.  
+ * In LBA mode, the (8 bits) register 0x1F3,0x1f4,0x1F5 and the lower 4 bits of 0x1F6,
+ * forms a 28-bit LBA address, so called LBA-28.
  * */
 int hd_cmd(uint drive, uint cmd, uint lba, uchar ns) {
     hd_wait_ready();
@@ -39,10 +39,10 @@ int hd_cmd(uint drive, uint cmd, uint lba, uchar ns) {
     return 0;
 }
 
-/* 
- * After we've send a command, we should wait for 400 nanosecond, then read the Status 
- * port. If the Busy bit is on, we should read the status port again until the Busy bit is 0; 
- * then we can read the results of the command. This operation is called "Polling". We can also 
+/*
+ * After we've send a command, we should wait for 400 nanosecond, then read the Status
+ * port. If the Busy bit is on, we should read the status port again until the Busy bit is 0;
+ * then we can read the results of the command. This operation is called "Polling". We can also
  * use IRQs instead of polling.
  * */
 int hd_wait_ready(){
@@ -55,10 +55,10 @@ int hd_wait_ready(){
 
 /* prepend it into devtab's waiting list(via av_prev, av_next),
  * if it's not active, send a request for the hard disk drive right
- * now. 
+ * now.
  * */
 int hd_request(struct buf *bp){
-    // prepend into the waiting list 
+    // prepend into the waiting list
     bp->av_prev = (struct buf*)&hdtab;
     bp->av_next = hdtab.av_next;
     hdtab.av_next->av_prev = bp;
@@ -70,9 +70,9 @@ int hd_request(struct buf *bp){
     return 0;
 }
 
-/* if waiting list is not empty, then take the tail, send a request 
+/* if waiting list is not empty, then take the tail, send a request
  * for the hard disk drive and mark it active.
- * note: BLK = (sizeof logical block) / (sizeof disk block), so 
+ * note: BLK = (sizeof logical block) / (sizeof disk block), so
  * physical address = lba * BLK
  * TODO: don't support two hd disk yet.
  * */
@@ -83,7 +83,7 @@ void hd_start(){
         return;
     }
     // take the tail
-    bp = hdtab.av_prev; 
+    bp = hdtab.av_prev;
     hdtab.d_active = 1;
     // read or write.
     if (bp->b_flag & B_READ) {
@@ -95,8 +95,8 @@ void hd_start(){
     }
 }
 
-/* interrupt handler of the hard disk drive, triggered on got 
- * data from the hard disk. get and remove the tail from the 
+/* interrupt handler of the hard disk drive, triggered on got
+ * data from the hard disk. get and remove the tail from the
  * waiting list, if there's still something inside it, hd_start()
  * again.
  * */
@@ -105,7 +105,7 @@ int do_hd_intr(struct trap *tf){
 
     if (hdtab.d_active == 0) {
         return 0;
-    } 
+    }
     hdtab.d_active = 0;
     bp = hdtab.av_prev;
     bp->av_prev->av_next = bp->av_next;

--- a/src/boot/boot.S
+++ b/src/boot/boot.S
@@ -13,9 +13,9 @@ _read_sect:
     mov     ax, si              ; disk sector number
     mov     bx, di              ; buffer address.
     ; ch = cylinder = sn / 36
-    mov     cl, 36              
-    div     cl                  
-    mov     ch, al              
+    mov     cl, 36
+    div     cl
+    mov     ch, al
     ; dh = head = (sn%36)/18
     mov     al, ah
     mov     ah, 0
@@ -23,11 +23,11 @@ _read_sect:
     div     cl
     mov     dh, al
     ; cl = sector = (ln%36)%18+1
-    mov     cl, ah 
+    mov     cl, ah
     inc     cl
-    ; dl = drive = 0; 
+    ; dl = drive = 0;
     mov     dl, 0
-    ; raise int 13h 
+    ; raise int 13h
     mov     ax, 201h
     int     13h
     pop     bx
@@ -37,7 +37,7 @@ _read_sect:
 ;; -----------------------------------------------------------------------
 ;;
 ;; bootloader starts here
-;; 
+;;
 
 [global _start]
 _start:
@@ -57,8 +57,8 @@ _reset_drive:
     ;
     mov     ax, 0x1000
     mov     es, ax               ; es = 1000h
-    mov     di, 0                ; 
-    mov     si, 1                ; 
+    mov     di, 0                ;
+    mov     si, 1                ;
     mov     cx, 128              ; read 128 sectors, 64kb
 _read_sect_loop:
     call    _read_sect
@@ -127,7 +127,7 @@ _start_pm:
     ; never return it should  be
     jmp     08h:100000h
 
-_hang: 
+_hang:
     jmp     _hang
 
 gdt:

--- a/src/chr/keybd.c
+++ b/src/chr/keybd.c
@@ -14,7 +14,7 @@
  *
  * */
 
-static uint mode = 0; 
+static uint mode = 0;
 
 /* translate into flags which indicated the satus of shift, ctrl & alt. */
 char shift(char sc){
@@ -38,8 +38,8 @@ char shift(char sc){
 }
 
 /*
- * Each keyboard interrupt came along with a 8bit scan code (via inb(KB_DATA)), if bit 8 is 
- * set, it's releasing a key, else pressing. 
+ * Each keyboard interrupt came along with a 8bit scan code (via inb(KB_DATA)), if bit 8 is
+ * set, it's releasing a key, else pressing.
  * */
 int do_keybd_intr(struct trap *tf){
     uchar sc, ch, m;
@@ -52,18 +52,18 @@ int do_keybd_intr(struct trap *tf){
     sc = inb(KB_DATA);
 
     // ignore capslock yet.
-    if ((sc & 0x7f) == 0x3A) 
+    if ((sc & 0x7f) == 0x3A)
         return 0;
 
     // check E0ESC
-    if (sc == 0xE0) 
+    if (sc == 0xE0)
         mode |= E0ESC;
 
     // check shift, ctrl and alt
     if ((m = shift(sc))) {
-        if (sc & 0x80) 
+        if (sc & 0x80)
             mode &= ~m;
-        else 
+        else
             mode |= m;
         return 0;
     }
@@ -72,7 +72,7 @@ int do_keybd_intr(struct trap *tf){
 
     if (mode & CTRL) {
         switch(ch){
-        case 'c': ch = CINTR; 
+        case 'c': ch = CINTR;
         case 'd': ch = CEOF;
         case 'x': ch = CKILL;
         case 'q': ch = CSTART;
@@ -82,7 +82,7 @@ int do_keybd_intr(struct trap *tf){
         }
     }
 
-    // on pressed 
+    // on pressed
     if ((sc & 0x80)==0 && ch!='\0') {
         tty_input(&tty[0], ch);
     }

--- a/src/chr/tty.c
+++ b/src/chr/tty.c
@@ -26,7 +26,7 @@ int putq(struct qbuf *qb, char ch){
     return 0;
 }
 
-/* Get the first character from a tty buf. 
+/* Get the first character from a tty buf.
  * */
 char getq(struct qbuf *qb){
     char ch;
@@ -58,7 +58,7 @@ char eraseq(struct qbuf *qb){
 int tty_canon(struct tty *tp){
     char ch;
     int i;
-    
+
     // if raw mode
     if (tp->t_flag & TTY_RAW) {
         while ((ch=getq(&tp->t_rawq)) >= 0) {
@@ -89,11 +89,11 @@ int tty_canon(struct tty *tp){
 /* output characters with buffering */
 int tty_output(struct tty *tp, char ch){
     int i;
-    // 
+    //
     switch(ch){
     case '\t':
         // expand tab into spaces
-        for(i=0; i<4-(tp->t_col%4); i++) 
+        for(i=0; i<4-(tp->t_col%4); i++)
             putq(&tp->t_outq, ' ');
         break;
     default:
@@ -104,7 +104,7 @@ int tty_output(struct tty *tp, char ch){
 }
 
 /*
- * Place a character on raw TTY input queue, if a carriage character 
+ * Place a character on raw TTY input queue, if a carriage character
  * arrives, wake up the awaitors.
  * */
 int tty_input(struct tty *tp, char ch){
@@ -194,7 +194,7 @@ int tty_read(ushort dev, char *buf, uint cnt){
     if (tp->t_canq.q_count < cnt) {
         sleep((uint)tp, PRITTY);
     }
-    // 
+    //
     for (i=0; i<cnt; i++) {
         if ((ch=getq(&tp->t_canq)) < 0)
             break;
@@ -206,7 +206,7 @@ int tty_read(ushort dev, char *buf, uint cnt){
 int tty_write(ushort dev, char *buf, uint cnt){
     struct tty *tp;
     int i;
-    
+
     if (MINOR(dev) >= NTTY){
         syserr(ENODEV);
         return -1;

--- a/src/chr/vga.c
+++ b/src/chr/vga.c
@@ -4,10 +4,10 @@
 
 #include <tty.h>
 
-/* 
+/*
  * vga.c
  *
- * This file indicated how to display text on the terminal, no 
+ * This file indicated how to display text on the terminal, no
  * xxx_init() needed. And you can take printk() almost every
  * where among this kernel.
  * */
@@ -67,7 +67,7 @@ void putch(char c) {
             vgamem[py][px].vc_char = ' ';
         }
         else {
-            if (py>0) 
+            if (py>0)
                 py--;
             px = 79;
             vgamem[py][px].vc_char = ' ';
@@ -108,14 +108,14 @@ void printn(uint n, uint b){
     static char *ntab = "0123456789ABCDEF";
     uint a, m;
     if ((a = n / b)){
-        printn(a, b);  
+        printn(a, b);
     }
     m = n % b;
     putch( ntab[m] );
 }
 
 /* a simpler printk
- * refer to unix v6 
+ * refer to unix v6
  * */
 void printk(char *fmt, ...){
     char c;

--- a/src/fs/alloc.c
+++ b/src/fs/alloc.c
@@ -2,7 +2,7 @@
 #include <x86.h>
 #include <proto.h>
 #include <proc.h>
-// 
+//
 #include <buf.h>
 #include <conf.h>
 //
@@ -10,9 +10,9 @@
 #include <inode.h>
 #include <stat.h>
 
-/* alloc one disk block in order to extend one file. returns 
+/* alloc one disk block in order to extend one file. returns
  * its LBA.
- * note: only called in bmap(, , 1). 
+ * note: only called in bmap(, , 1).
  * note2: here assumes each zone equals one block.
  * */
 int balloc(ushort dev){
@@ -40,13 +40,13 @@ int balloc(ushort dev){
     return -1;
 }
 
-/* free a block. 
+/* free a block.
  * */
 int bfree(ushort dev, uint nr){
     struct buf *bp;
     struct super *sp;
     uint bn;
-    
+
     sp = getsp(dev);
     if ((nr < sp->s_data_zone0) || (nr >= sp->s_max_zone)) {
         panic("freeing a block not in data zone");
@@ -89,7 +89,7 @@ int ialloc(ushort dev){
     sp = getsp(dev);
     for (nr=0; nr < sp->s_max_inode; nr++){
         bp = bread(dev, IMAPBLK(sp, nr));
-        r = find_bit(bp->b_data, BLK);   
+        r = find_bit(bp->b_data, BLK);
         if (r < 0) {
             continue;
         }
@@ -108,7 +108,7 @@ int ialloc(ushort dev){
 void ifree(ushort dev, uint ino){
     struct buf *bp;
     struct super *sp;
-    
+
     sp = getsp(dev);
     if ((ino <= 0) || (ino >= sp->s_max_inode)) {
         panic("freeing an non-existing inode");

--- a/src/fs/bmap.c
+++ b/src/fs/bmap.c
@@ -1,7 +1,7 @@
 #include <param.h>
 #include <x86.h>
 #include <proc.h>
-// 
+//
 #include <buf.h>
 #include <conf.h>
 //
@@ -15,14 +15,14 @@
  * Given an inode and a position within the corresponding file, locate the
  * block (not zone) number in which that position is to be found and return it.
  * returns 0 on error.
- * note: 
- * the first 7 entry of ip->zones[] are direct pointers, ip->zone[7] is an indirect 
+ * note:
+ * the first 7 entry of ip->zones[] are direct pointers, ip->zone[7] is an indirect
  * pointer to a zone map, while ip->zone[8] is an double indirect pointer to a zone map.
  * note2: file extends only here.
  *
  * ip->i_size is adjusted in writei();
  *
- * TODO: maybe we can remove all the updatei and bwrite stuff, but sync() is to be implemented 
+ * TODO: maybe we can remove all the updatei and bwrite stuff, but sync() is to be implemented
  * first.
  */
 int bmap(struct inode *ip, ushort nr, uchar creat) {
@@ -80,7 +80,7 @@ int bmap(struct inode *ip, ushort nr, uchar creat) {
         bzero(dev, ip->i_zone[8]);
         ip->i_flag |= I_DIRTY;
         iupdate(ip);
-    } 
+    }
     bp = bread(dev, ip->i_zone[8]);
     zmap = (short *)bp->b_data;
     if (zmap[nr/NINDBLK]==0) {
@@ -107,10 +107,10 @@ int bmap(struct inode *ip, ushort nr, uchar creat) {
 
 /*
  * Discard inode's content.
- * Called from routines like open(), iput(). 
+ * Called from routines like open(), iput().
  * */
 int itrunc(struct inode *ip){
-    int i,j; 
+    int i,j;
     ushort dev;
     struct buf *bp, *bp2;
     char *zmap, *zmap2;
@@ -119,7 +119,7 @@ int itrunc(struct inode *ip){
     if (!(ip->i_mode & S_IFREG) || (ip->i_mode & S_IFDIR)) {
         return -1;
     }
-    
+
     dev = ip->i_dev;
     for (i=0; i<7; i++){
         if (ip->i_zone[i]!=0){

--- a/src/fs/fcntl.c
+++ b/src/fs/fcntl.c
@@ -2,7 +2,7 @@
 #include <x86.h>
 #include <proto.h>
 #include <proc.h>
-// 
+//
 #include <buf.h>
 #include <conf.h>
 //
@@ -16,15 +16,15 @@ struct file file[NFILE];
 /* -------------------------------------------------------------- */
 
 /*
- * fcntl() performs one of the operations described below on the 
+ * fcntl() performs one of the operations described below on the
  * open file descriptor fd. The operation is determined by cmd.
- * Also there is an optional thrid argument, which associated with 
+ * Also there is an optional thrid argument, which associated with
  * the second argument cmd.
  * */
 /* TODO: add other commands */
 int do_fcntl(int fd, uint cmd, uint arg){
     struct file *fp;
-    
+
     fp = cu->p_ofile[fd];
     if (fd>=NOFILE || fd<0 || fp==NULL){
         syserr(EBADF);
@@ -75,7 +75,7 @@ int do_stat(struct inode *ip, struct stat *sbuf){
 
 /* -------------------------------------------------------------- */
 
-/* check file access and permssion. mode is R_OK, W_OK and X_OK. 
+/* check file access and permssion. mode is R_OK, W_OK and X_OK.
  * In the case of write, the read-only status of the file system is
  * checked.
  * The super user is granted all permissions except for EXEC where
@@ -86,7 +86,7 @@ int do_stat(struct inode *ip, struct stat *sbuf){
 int do_access(struct inode *ip, uint mode){
     struct super *sp;
     uint m;
-    
+
     if (ip==NULL) {
         syserr(EACCES);
         return -1;
@@ -121,7 +121,7 @@ int do_access(struct inode *ip, uint mode){
         m >>= 6;
     else if (cu->p_egid == ip->i_gid)
         m >>= 3;
-    // 
+    //
     if ((m & 07 & mode)==mode) {
         return 0;
     }
@@ -131,7 +131,7 @@ int do_access(struct inode *ip, uint mode){
 
 /* -------------------------------------------------------------- */
 
-/* 
+/*
  * creat a new file if not existing yet. if existed, truncate it.
  * this routine also returns a file descriptor just like do_open().
  * */
@@ -139,7 +139,7 @@ int do_creat(char *path, int mode){
     return do_open(path, O_CREAT | O_TRUNC, mode);
 }
 
-/* 
+/*
  * */
 int do_mknod(char *path, int mode, ushort dev){
     struct inode *ip;

--- a/src/fs/inode.c
+++ b/src/fs/inode.c
@@ -1,7 +1,7 @@
 #include <param.h>
 #include <x86.h>
 #include <proc.h>
-// 
+//
 #include <buf.h>
 #include <conf.h>
 //
@@ -21,16 +21,16 @@ struct inode inode[NINODE];
  * iupdate -> write changes back to disk.
  * */
 
-/* get an (locked) inode via an number 
+/* get an (locked) inode via an number
  * if the inode is in cache, return it right now.
  * return NULL on error.
  * note1: you may compare this code with getblk, the idea here
  * is common used among everywhere on resource allocation.
- * it returns ONLY locked inode just as B_BUSY in getblk, just 
+ * it returns ONLY locked inode just as B_BUSY in getblk, just
  * to prevent other processes' accessing within one syscall.
  *
  * note2: though there is still some differences between getblk,
- * put an eye on *reference count*, lock won't stays long(within 
+ * put an eye on *reference count*, lock won't stays long(within
  * one syscall, like the open routine, which unlock the inode at
  * last), though *reference count* ramains set between syscalls
  * to prevent the kernel from reallocating active in-core inode.
@@ -79,12 +79,12 @@ _loop:
             return ip;
         }
     }
-    // if not found (no free slot) 
+    // if not found (no free slot)
     printk("inode table overflow.\n");
     return NULL;
 }
 
-/* 
+/*
  * release an inode.
  * decrease the reference count, write updates to disk if nessary.
  * also check the link count, if zero, trucate it.
@@ -122,7 +122,7 @@ void iput(struct inode *ip){
 
 /***************************************************/
 
-/* load a inode from disk 
+/* load a inode from disk
  * */
 int iload(struct inode *ip){
     struct super *sp;

--- a/src/fs/link.c
+++ b/src/fs/link.c
@@ -2,7 +2,7 @@
 #include <x86.h>
 #include <proto.h>
 #include <proc.h>
-// 
+//
 #include <buf.h>
 #include <conf.h>
 //
@@ -13,8 +13,8 @@
 #include <stat.h>
 
 /*
- * link path1 to path2. 
- * path1 is existing yet, create a new directory entry for path2, 
+ * link path1 to path2.
+ * path1 is existing yet, create a new directory entry for path2,
  * and increase the reference count of path1's inode.
  * */
 int do_link(char *path1, char *path2){
@@ -62,7 +62,7 @@ int do_link(char *path1, char *path2){
     return 0;
 
 _bad_name:
-    // undo something 
+    // undo something
     lock_ino(tip);
     tip->i_nlink--;
     iupdate(tip);
@@ -74,7 +74,7 @@ _bad_name:
 /*
  * remove a link to a file.
  * this file should not be a directory.
- * returns 0 on success. 
+ * returns 0 on success.
  * */
 int do_unlink(char *path){
     struct inode *ip, *dip;
@@ -82,7 +82,7 @@ int do_unlink(char *path){
     char *name;
 
     dip = namei_parent(path, &name);
-    // on path=='/' 
+    // on path=='/'
     if (strlen(name)==0 || strlen(name) >= NAMELEN)
         goto _bad_name;
     if (strcmp(name, ".")==0 || strcmp(name, "..")==0)
@@ -90,7 +90,7 @@ int do_unlink(char *path){
 
     ino = unlink_entry(dip, name, strlen(name));
     // entry not found
-    if (ino<=0) 
+    if (ino<=0)
         goto _bad_name;
     ip = iget(dip->i_dev, ino);
     // can't unlink a directory, undo something.

--- a/src/fs/mount.c
+++ b/src/fs/mount.c
@@ -18,7 +18,7 @@ struct super *rootsp = NULL;
  * if did not got any free slot, just simply raise an error instead
  * of sleep until somebody frees like what getblk does.
  * if dev==rootdev, set a pointer rootsp for a quicker access.
- * 
+ *
  * */
 struct super* do_mount(ushort dev, struct inode *ip){
     struct super *sp;
@@ -51,7 +51,7 @@ _found:
     if (dev==rootdev) {
         rootsp = sp;
     }
-    if (ip!=NULL) 
+    if (ip!=NULL)
         ip->i_count++;
     sp->s_imnt = ip;
     unlk_sp(sp);
@@ -71,7 +71,7 @@ int do_umount(ushort dev){
         if (ip->i_num!=0 && ip->i_dev==dev) {
             syserr(EBUSY);
             return -1;
-        } 
+        }
     }
     spupdate(sp);
     sp->s_dev = 0;

--- a/src/fs/namei.c
+++ b/src/fs/namei.c
@@ -2,7 +2,7 @@
 #include <x86.h>
 #include <proto.h>
 #include <proc.h>
-// 
+//
 #include <buf.h>
 #include <conf.h>
 //
@@ -12,7 +12,7 @@
 #include <stat.h>
 
 
-/* 
+/*
  * fetch an inode number from a single directory file (via a locked inode, make sure
  * it's an directory).
  * returns 0 on fail.
@@ -78,7 +78,7 @@ int unlink_entry(struct inode *dip, char *name, int len){
 }
 
 /*
- * assign a new directory entry with a given inode. 
+ * assign a new directory entry with a given inode.
  * note: this routine do NOT check the existence of the given name,
  * and i_nlinks is not adjusted here.
  * */
@@ -119,7 +119,7 @@ struct inode* _namei(char *path, uchar creat, uchar parent, char **name){
     char* tmp;
 
     // if path starts from root
-    // note if p_wdir==NULL, it's an early initialized process, 
+    // note if p_wdir==NULL, it's an early initialized process,
     // set it's root directory here.
     if (*path == '/') {
         wip = iget(rootdev, ROOTINO);

--- a/src/fs/open.c
+++ b/src/fs/open.c
@@ -2,7 +2,7 @@
 #include <x86.h>
 #include <proto.h>
 #include <proc.h>
-// 
+//
 #include <buf.h>
 #include <conf.h>
 //
@@ -16,11 +16,11 @@ struct file file[NFILE];
 /* ------------------------------------------------------------- */
 
 /*
- * open a file. flag indicated opened type like O_RDONLY, O_TRUNC, O_CREAT and blah. And 
+ * open a file. flag indicated opened type like O_RDONLY, O_TRUNC, O_CREAT and blah. And
  * mode only used in the O_CREAT scenary, indicated the file (inode) type.
  *
  * each proc has got one user file table(p_ofile[NOFILE]), it's each entry is also a number,
- * indicated the number in the system file table(file[NFILE]). when user opened a file, it 
+ * indicated the number in the system file table(file[NFILE]). when user opened a file, it
  * first allocate a user file table entry(aka. file descriptor), then attach it with a system
  * file table entry. It's reference count is increased in fork() or dup().
  * */
@@ -50,7 +50,7 @@ int do_open(char *path, uint flag, uint mode){
             syserr(ENFILE);
             return -1;
         }
-        // TODO: check access 
+        // TODO: check access
         // if it's a device file, the dev number is stored in zone[0].
         dev = ip->i_zone[0];
         switch(ip->i_mode & S_IFMT) {
@@ -61,7 +61,7 @@ int do_open(char *path, uint flag, uint mode){
                 (*cdevsw[MAJOR(dev)].d_open)(dev);
                 break;
         }
-    } 
+    }
     if (((fd=ufalloc())<0) || (fp=falloc(fd))==NULL) {
         iput(ip);
         return -1;
@@ -78,7 +78,7 @@ int do_open(char *path, uint flag, uint mode){
 
 /*
  * close a user file discriptor.
- * remove the entry in the user file table, and decrease the entry in system 
+ * remove the entry in the user file table, and decrease the entry in system
  * file table's ref count. and iput the inode.
  * */
 int do_close(int fd){
@@ -146,7 +146,7 @@ int do_dup2(int fd, int newfd){
 /* allocate a user file descriptor. */
 int ufalloc(){
     int i;
-    
+
     for(i=0; i<NOFILE; i++){
         if (cu->p_ofile[i]==NULL) {
             return i;

--- a/src/fs/rdwr.c
+++ b/src/fs/rdwr.c
@@ -2,7 +2,7 @@
 #include <x86.h>
 #include <proto.h>
 #include <proc.h>
-// 
+//
 #include <buf.h>
 #include <tty.h>
 #include <conf.h>
@@ -65,7 +65,7 @@ int do_write(int fd, char *buf, int cnt){
     struct inode *ip;
     int r, off;
     uint dev;
-    
+
     fp = cu->p_ofile[fd];
     if ( fd<0 || fd>NOFILE || fp==NULL) {
         syserr(ENFILE);
@@ -87,7 +87,7 @@ int do_write(int fd, char *buf, int cnt){
     ip = fp->f_ino;
     switch(ip->i_mode & S_IFMT) {
     case S_IFBLK:
-        // TODO: 
+        // TODO:
         break;
     case S_IFCHR:
         dev = ip->i_zone[0];
@@ -109,7 +109,7 @@ int do_write(int fd, char *buf, int cnt){
 }
 
 /*
- * reposition the opened file asscociated with the file descriptor fd 
+ * reposition the opened file asscociated with the file descriptor fd
  * to the argument off, according to the directive whence below:
  *  SEEK_SET: set the offset as the argument off
  *  SEEK_CUR: set the offset to its current location plus off bytes.
@@ -129,12 +129,12 @@ int do_lseek(uint fd, int off, int whence){
     }
 
     if (whence==SEEK_SET) {
-        if (off < 0) 
+        if (off < 0)
             goto _einval;
         fp->f_offset = off;
     }
-    if (whence==SEEK_CUR) { 
-        if (fp->f_offset+off < fp->f_offset) 
+    if (whence==SEEK_CUR) {
+        if (fp->f_offset+off < fp->f_offset)
             goto _einval;
         fp->f_offset += off;
     }

--- a/src/fs/rdwri.c
+++ b/src/fs/rdwri.c
@@ -2,7 +2,7 @@
 #include <x86.h>
 #include <proto.h>
 #include <proc.h>
-// 
+//
 #include <buf.h>
 #include <conf.h>
 //
@@ -15,7 +15,7 @@
  * TODO: ignored special files yet.
  * */
 
-/* 
+/*
  * read data from a locked inode.
  * returns -1 on error.
  * */
@@ -23,7 +23,7 @@ int readi(struct inode *ip, char *buf, uint off, uint cnt){
     struct buf *bp;
     uint tot=0, m=0, bn=0;
 
-    // file size limit 
+    // file size limit
     if ((off > ip->i_size) || (off+cnt < off)){
         cu->p_error = E2BIG;
         return -1;

--- a/src/fs/super.c
+++ b/src/fs/super.c
@@ -2,7 +2,7 @@
 #include <x86.h>
 #include <proto.h>
 #include <proc.h>
-// 
+//
 #include <buf.h>
 #include <conf.h>
 //
@@ -13,7 +13,7 @@
 struct super    mnt[NMOUNT] = { {0, }, };
 
 /* search the mount table.
- * note: super block is meaningless until the device is mounted 
+ * note: super block is meaningless until the device is mounted
  * */
 struct super* getsp(ushort dev){
     struct super *sp;
@@ -46,7 +46,7 @@ int spload(struct super *sp){
     bp = bread(sp->s_dev, 1);
     if ((bp->b_flag & B_ERROR)!=0){
         panic("disk read error");
-        return -1;   
+        return -1;
     }
     memcpy(sp, bp->b_data, sizeof(struct d_super));
     brelse(bp);
@@ -63,7 +63,7 @@ int spload(struct super *sp){
  * */
 void spupdate(struct super *sp){
     struct buf *bp;
-    
+
     bp = getblk(sp->s_dev, 1);
     memcpy(bp->b_data, (char*)sp, sizeof(struct d_super));
     bwrite(bp);
@@ -77,7 +77,7 @@ void update(){
 
 /* ---------------------------------------------- */
 
-/* 
+/*
  * unlock(release) a super
  * */
 void unlk_sp(struct super *sp){

--- a/src/inc/a.out.h
+++ b/src/inc/a.out.h
@@ -10,7 +10,7 @@ struct ahead {
   uint      a_entry;		/* start address */
   uint      a_trsize;		/* size of relocation info for text, in bytes */
   uint      a_drsize;		/* size of relocation info for data, in bytes */
-}; 
+};
 
 #define NMAGIC 0x6400CC
 

--- a/src/inc/asm.h
+++ b/src/inc/asm.h
@@ -2,8 +2,8 @@
 
 struct pde;
 
-/* 
- * iodelay. On older machines its necessary to give the PIC some time to react to 
+/*
+ * iodelay. On older machines its necessary to give the PIC some time to react to
  * commands as they might not be processed quickly.
  * */
 static inline void io_delay(){

--- a/src/inc/buf.h
+++ b/src/inc/buf.h
@@ -18,16 +18,16 @@ extern struct buf   buff[NBUF];
 
 /*
  * Each block device has a devtab, which contains private
- * state stuff and 2 list head: the b_head/b_tail list, 
- * which is doubly linked and has all the buffers currently 
+ * state stuff and 2 list head: the b_head/b_tail list,
+ * which is doubly linked and has all the buffers currently
  * associated with that major device;
- * and the av_head/av_tail list, which is private to the 
+ * and the av_head/av_tail list, which is private to the
  * device but in fact is always used for the head and tail
  * of the IO queue for the device.
  * Various routines in bio.c look at b_head/b_tail
- * but the rest is private to each device driver. 
+ * but the rest is private to each device driver.
  *
- * note: Little trick here, devtab's header can be also 
+ * note: Little trick here, devtab's header can be also
  * visited via a struct buf *.
  * */
 struct devtab {

--- a/src/inc/conf.h
+++ b/src/inc/conf.h
@@ -6,13 +6,13 @@
 struct buf;
 
 struct bdevsw {
-    int             (*d_open)(); 
+    int             (*d_open)();
     int             (*d_close)();
     int             (*d_request)(struct buf *bp);
     struct devtab    *d_tab;
 };
 
-extern struct bdevsw    bdevsw[NBLKDEV];   
+extern struct bdevsw    bdevsw[NBLKDEV];
 
 struct cdevsw {
     int             (*d_open)   (ushort dev);

--- a/src/inc/file.h
+++ b/src/inc/file.h
@@ -18,22 +18,22 @@ extern struct file file[NFILE];
 #define O_RDONLY	0x0     // read only
 #define O_WRONLY	0x1     // write only
 #define O_RDWR		0x2     // read / write
-#define O_APPEND	0x40    // 
+#define O_APPEND	0x40    //
 /* the rest can not be modified by fcntl */
 #define O_CREAT		0x4     // creat a new file.
-#define O_EXCL		0x8     // a execulsive open 
-#define O_NOCTTY	0x10    // 
+#define O_EXCL		0x8     // a execulsive open
+#define O_NOCTTY	0x10    //
 #define O_TRUNC		0x20    //
 #define O_NONBLOCK	0x80    //
 
 /* fcntl */
 #define F_DUPFD		0	/* dup */
-#define F_GETFD		1	/* seems only FD_CLOEXEC associated with this. */ 
-#define F_SETFD		2	
+#define F_GETFD		1	/* seems only FD_CLOEXEC associated with this. */
+#define F_SETFD		2
 #define F_GETFL		3	/* get f_flag */
 #define F_SETFL		4   /* set f_flag */
 #define F_GETLK		5	/* aquire a lock. (not implemented) */
-#define F_SETLK		6   
+#define F_SETLK		6
 #define F_SETLKW	7
 
 #define FD_CLOEXEC 1    /* close this file on exec. (not implemented) */

--- a/src/inc/hd.h
+++ b/src/inc/hd.h
@@ -21,7 +21,7 @@ extern struct hd_minor hd_minor[16];
 #define HD_CMD_WRITE   0x30
 
 /* flags for HD_STAT */
-#define HD_BSY	  0x80 
+#define HD_BSY	  0x80
 #define HD_DRDY	  0x40 //Device Ready
 #define HD_DF     0x20 //Device Fault
 #define HD_ERR	  0x01

--- a/src/inc/idt.h
+++ b/src/inc/idt.h
@@ -17,13 +17,13 @@ struct gate_desc {
 struct idt_desc {
     ushort      limit;
     uint        base;
-} __attribute__((packed));     
+} __attribute__((packed));
 
 struct trap {
     int        gs, fs, es, ds;                             /* pushed the segs last */
     int        edi, esi, ebp, _esp, ebx, edx, ecx, eax;    /* pushed by 'pusha', note the esp here is ignored. */
     int        int_no, err_code;                           /* our 'push byte #' and ecodes do this */
-    int        eip, cs, eflags, esp, ss;                   /* pushed by the processor automatically */ 
+    int        eip, cs, eflags, esp, ss;                   /* pushed by the processor automatically */
 } __attribute__((packed));
 
 /* constants on PIC */

--- a/src/inc/inode.h
+++ b/src/inc/inode.h
@@ -1,7 +1,7 @@
 #ifndef INODE_H
 #define INODE_H
 
-/* 
+/*
  * the Minix v1 fs, you could build one via mkfs.minix under linux.
  * */
 

--- a/src/inc/mmu.h
+++ b/src/inc/mmu.h
@@ -26,7 +26,7 @@ struct pte {
 #define PTE_PS		0x080	// Page Size
 #define PTE_MBZ		0x180	// Bits must be zero
 
-/* 
+/*
  * A linear address 'la' has a three-part structure as follows:
  *
  * +--------10------+-------10-------+---------12----------+
@@ -44,7 +44,7 @@ struct pte {
 
 #define PG_ADDR(addr)   ((uint)(addr) & ~0xFFF)
 
-/* CR2 stores the virtual address on which raised the page fault. 
+/* CR2 stores the virtual address on which raised the page fault.
  * error code stores inside the trap frame.
  * */
 

--- a/src/inc/proc.h
+++ b/src/inc/proc.h
@@ -18,7 +18,7 @@ struct proc {
     int                 p_cpu;          /* - */
     int                 p_nice;         /* - */
     int                 p_time;         /* on swap */
-    uint                p_pid;          
+    uint                p_pid;
     uint                p_ppid;         /* parent's pid */
     uint                p_pgrp;         /* process group */
     uint                p_euid;         /* effective uid */
@@ -46,7 +46,7 @@ extern struct proc *proc[NPROC];
 extern struct proc *cu;
 
 /* flag for re-scheduling */
-extern uint runrun; 
+extern uint runrun;
 
 /* stat codes */
 #define SSLEEP      1           // sleeping on high priority (unitterruptible)

--- a/src/inc/proto.h
+++ b/src/inc/proto.h
@@ -193,7 +193,7 @@ uint find_entry(struct inode* dip, char *name, uint len);
 uint link_entry(struct inode *dip, char *name, uint len, uint ino);
 int unlink_entry(struct inode *dip, char *name, int len);
 
-// fs/file.c 
+// fs/file.c
 struct file* falloc(int fd);
 
 // fs/super.c

--- a/src/inc/stat.h
+++ b/src/inc/stat.h
@@ -2,14 +2,14 @@
 #define STAT_H
 
 struct stat {
-    ushort  st_dev; 
+    ushort  st_dev;
     ushort  st_ino;
     ushort  st_mode;
-    ushort  st_nlink;  
+    ushort  st_nlink;
     ushort  st_uid;
     ushort  st_gid;
     ushort  st_rdev;
-    uint    st_size;  
+    uint    st_size;
     ushort  st_atime;
     ushort  st_mtime;
     ushort  st_ctime;

--- a/src/inc/super.h
+++ b/src/inc/super.h
@@ -1,6 +1,6 @@
 /* it's a minix 2 fs's super block.
  * note that each minor device's first logical block(1024b, 2 physical block)
- * is reserved for the boot record, the second logical block is reserved for the 
+ * is reserved for the boot record, the second logical block is reserved for the
  * super block, which is also 1024b.
  * */
 struct d_super {

--- a/src/inc/tty.h
+++ b/src/inc/tty.h
@@ -22,7 +22,7 @@ struct tty {
     int     t_col;  // position x of the cursor
     int     t_row;  // position y of the cursor
     void    (*t_putc)(char);
-    struct qbuf    t_rawq; 
+    struct qbuf    t_rawq;
     struct qbuf    t_canq;
     struct qbuf    t_outq;
 };

--- a/src/inc/unistd.h
+++ b/src/inc/unistd.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * unistd.h - fleurer<me.ssword@gmail.com>
  * some macro helpers on making syscall.
  **/
@@ -182,7 +182,7 @@ static inline _SYS3(int, open, char*, int, int);
 static inline _SYS2(int, creat, char*, int);
 static inline _SYS1(int, close, int);
 static inline _SYS3(int, fcntl, int, int, int);
-static inline _SYS3(int, mknod, char*, int, int); 
+static inline _SYS3(int, mknod, char*, int, int);
 static inline _SYS3(int, write, int, char*, int);
 static inline _SYS3(int, read, int, char*, int);
 static inline _SYS3(int, lseek, int, int, int);
@@ -191,11 +191,11 @@ static inline _SYS1(int, chroot, char*);
 static inline _SYS1(int, dup, int);
 static inline _SYS2(int, dup2, int, int);
 static inline _SYS2(int, link, char*, char*);
-static inline _SYS1(int, unlink, char*); 
-static inline _SYS2(int, stat, char*, struct stat*); 
-static inline _SYS2(int, fstat, int, struct stat*); 
+static inline _SYS1(int, unlink, char*);
+static inline _SYS2(int, stat, char*, struct stat*);
+static inline _SYS2(int, fstat, int, struct stat*);
 //
-static inline _SYS0(int, fork); 
+static inline _SYS0(int, fork);
 static inline _SYS2(int, exec, char*, char**);
 static inline _SYS1(int, _exit, int);
 //

--- a/src/inc/vm.h
+++ b/src/inc/vm.h
@@ -13,14 +13,14 @@ struct vma {
     uint            v_ioff; // keep block aligned
 };
 
-#define VMA_RDONLY  0x1  // read only 
+#define VMA_RDONLY  0x1  // read only
 #define VMA_STACK   0x2  // this vma indicates a stack, which grows downwards.
 #define VMA_ZERO    0x4  // demand-zero
 #define VMA_MMAP    0x8  // mapped from a file
-#define VMA_PRIVATE 0x10 // Copy On Write 
+#define VMA_PRIVATE 0x10 // Copy On Write
 
 /*
- * each proc got one struct vm, which indicated it's page directory 
+ * each proc got one struct vm, which indicated it's page directory
  * and misc on address space.
  * */
 struct vm {

--- a/src/kern/exec.c
+++ b/src/kern/exec.c
@@ -16,14 +16,14 @@
 #include <super.h>
 #include <inode.h>
 #include <file.h>
-// 
+//
 #include <a.out.h>
 
 /*
  * exec.c
  *
  * this file indicated the implementation of exec(char* path, char **argv).
- * exec() create a NEW address space, which overlapped the old forked address 
+ * exec() create a NEW address space, which overlapped the old forked address
  * space, make it demand-reading.
  * */
 
@@ -32,7 +32,7 @@ static int free_argv(char **tmp);
 
 /* ---------------------------------------------- */
 
-/* initialize a new struct vm according to an a.out executable 
+/* initialize a new struct vm according to an a.out executable
  * image.
  * returns NULL on fail.
  * the user stack initialized like this:
@@ -174,7 +174,7 @@ static char** store_argv(char *path, char **argv){
     int argc, i;
 
     argc = 1;
-    if (argv!=NULL) 
+    if (argv!=NULL)
         for (; argv[argc-1]; argc++);
     // store the argv in temp
     tmp    = (char**)kmalloc(PAGE);

--- a/src/kern/exit.c
+++ b/src/kern/exit.c
@@ -6,7 +6,7 @@
 #include <page.h>
 #include <vm.h>
 
-#include <conf.h>                      
+#include <conf.h>
 
 /* exit.c - 2011 fleurer
  * */
@@ -40,7 +40,7 @@ int do_exit(int ret){
     // free the address space
     vm_clear(&cu->p_vm);
     kfree(cu->p_vm.vm_pgd, PAGE);
-    // make this process Zombie, give all the children to proc[1] 
+    // make this process Zombie, give all the children to proc[1]
     // and tell its parent
     cu->p_chan = 0;
     cu->p_stat = SZOMB;

--- a/src/kern/fork.c
+++ b/src/kern/fork.c
@@ -6,12 +6,12 @@
 #include <page.h>
 #include <vm.h>
 
-#include <conf.h>                      
+#include <conf.h>
 
 /*
  * proc.c - 2010 fleurer
- * this file implies the initilization of proc[0] and the implementation 
- * of fork(), 
+ * this file implies the initilization of proc[0] and the implementation
+ * of fork(),
  *
  * */
 
@@ -20,7 +20,7 @@ struct proc proc0;
 struct proc *proc[NPROC] = {NULL, };
 struct proc *cu = NULL;
 
-struct tss_desc tss;              
+struct tss_desc tss;
 
 extern void _hwint_ret();
 
@@ -40,10 +40,10 @@ int find_pid(){
     return 0;
 }
 
-/* Spawn a kernel thread.    
+/* Spawn a kernel thread.
  * This is not quite cool, but we have to do some initialization in
- * kernel's address space, the approach in linux0.11 is not quite 
- * ease here for the fact that trap occured in the kernel space do 
+ * kernel's address space, the approach in linux0.11 is not quite
+ * ease here for the fact that trap occured in the kernel space do
  * not refering the esp in TSS.
  *
  * returns a pointer to the newly borned proc, one page size(with the kernel stack).
@@ -130,8 +130,8 @@ int do_fork(struct trap *tf){
 
 /* ----------------------------------------------------------- */
 
-/* 
- * init proc[0] 
+/*
+ * init proc[0]
  * set the LDT and th ONLY TSS into GDT
  * and make current as proc[0]
  */

--- a/src/kern/main.c
+++ b/src/kern/main.c
@@ -37,7 +37,7 @@ void kmain(){
     //
     kspawn(&init);
     for(;;){
-        sti(); 
+        sti();
         swtch();
     }
 }

--- a/src/kern/sched.c
+++ b/src/kern/sched.c
@@ -6,7 +6,7 @@
 #include <conf.h>
 
 /* TODO: the algorithm on runrun seems break */
-uint runrun = 0; 
+uint runrun = 0;
 
 /*******************************************************************************/
 
@@ -29,7 +29,7 @@ void sleep(uint chan, int pri){
         cu->p_pri = pri;
         cu->p_stat = SWAIT; // interruptible
         sti();
-        if (issig()) 
+        if (issig())
             psig();
         swtch();
     }
@@ -39,13 +39,13 @@ void wakeup(uint chan){
     struct proc *p;
     int i;
     for(i=0; i<NPROC; i++){
-        if ((p = proc[i]) == NULL) 
+        if ((p = proc[i]) == NULL)
             continue;
         if (p->p_chan == chan) {
             setrun(p);
         }
     }
-} 
+}
 
 void setrun(struct proc *p){
     p->p_chan = 0;
@@ -68,7 +68,7 @@ void setpri(struct proc *p){
     p->p_pri = n;
 }
 
-/* called once per second, re-caculate all the procs' p_pri 
+/* called once per second, re-caculate all the procs' p_pri
  * TODO: stil didn't catch the idea of traditional Unix's scheduling.
  * choose linus's approach instead later.
  * */
@@ -85,7 +85,7 @@ void sched_cpu(){
     }
 }
 
-/* 
+/*
  * find the next proc and switch it.
  * re-caculate the current proc's p_pri on the end of time quatum.
  * */
@@ -119,7 +119,7 @@ void swtch(){
  * */
 void swtch_to(struct proc *to){
     struct proc *from;
-    tss.esp0 = (uint)to + PAGE; 
+    tss.esp0 = (uint)to + PAGE;
     from = cu;
     cu = to;
     lpgd(to->p_vm.vm_pgd);

--- a/src/kern/seg.c
+++ b/src/kern/seg.c
@@ -15,7 +15,7 @@ void set_seg(struct seg_desc *seg, uint base, uint limit, uint dpl, uint type){
     seg->type     = type;
     seg->s        = 1;
     seg->dpl      = dpl;
-    seg->present  = 1; 
+    seg->present  = 1;
     seg->limit_hi = (uint) (limit) >> 28;
     seg->avl      = 0;
     seg->r        = 0;
@@ -39,7 +39,7 @@ void set_tss(struct seg_desc *seg, uint base){
 
 /* ------------------------------------------------------ */
 
-/* 
+/*
  * refill the gdt(the ex-gdt initialized in boot/boot.S)
  * one tss is shared among all processes.
  */

--- a/src/kern/signal.c
+++ b/src/kern/signal.c
@@ -47,8 +47,8 @@ int issig(){
 
 /*
  * perform the action specified by the current signal.
- * the usual sequence is: 
- * if (issig()) 
+ * the usual sequence is:
+ * if (issig())
  *      psig();
  * */
 void psig(){
@@ -67,7 +67,7 @@ void psig(){
     cu->p_cursig = 0;
     if (sa->sa_handler != SIG_DFL) {
         tf = cu->p_trap;
-        // save registers and the old sa_mask 
+        // save registers and the old sa_mask
         usigsav(&jbuf, tf, cu->p_sigmask);
         // store the new sa_mask
         if ((sa->sa_flags & SA_NOMASK)==0) {
@@ -132,7 +132,7 @@ void usigsav(struct jmp_buf *buf, struct trap *tf, uint mask){
 /* send a signal to a process.*/
 int sigsend(int pid, int n, int priv){
     struct proc *p;
-    
+
     p = proc[pid];
     if (pid==0 || p==NULL || n<0 || n>=NSIG) {
         syserr(EINVAL);
@@ -142,7 +142,7 @@ int sigsend(int pid, int n, int priv){
         syserr(EPERM);
         return -1;
     }
-    if (p->p_sigact[n-1].sa_handler==SIG_IGN && n!=SIGKILL) 
+    if (p->p_sigact[n-1].sa_handler==SIG_IGN && n!=SIGKILL)
         return -1;
 
     p->p_sig |= (1<<(n-1));
@@ -179,15 +179,15 @@ int do_kill(int pid, int sig){
     struct proc *p;
     int nr, ret;
 
-    if (pid>0) 
+    if (pid>0)
         return sigsend(pid, sig, 0);
-    if (pid==0) 
+    if (pid==0)
         return sigsend_g(cu->p_pid, sig, 0);
-    if (pid < -1) 
+    if (pid < -1)
         return sigsend_g(-pid, sig, 0);
     if (pid==-1) {
         for (nr=1; nr<NPROC; nr++) {
-            if ((p=proc[nr])) 
+            if ((p=proc[nr]))
                 ret = sigsend(nr, sig, 0);
         }
         return ret;
@@ -201,7 +201,7 @@ int do_sigaction(int sig, struct sigaction *sa, struct sigaction *old_sa){
         syserr(EINVAL);
         return -1;
     }
-    // store the old struct sigaction 
+    // store the old struct sigaction
     if (old_sa!=NULL) {
         if (vm_verify(old_sa, sizeof(struct sigaction))<0) {
             syserr(EFAULT);

--- a/src/kern/sys2.c
+++ b/src/kern/sys2.c
@@ -12,11 +12,11 @@
 
 /* syscalls on fs */
 
-/* 
+/*
  * WARNING: DANGEROUS here! While passing data between kernel
- * and user, a verification is nesscary. Just make a simulation 
- * what the hardware does in user space, or it may cause corruption, 
- * even overlaps the kernel memory, be careful. 
+ * and user, a verification is nesscary. Just make a simulation
+ * what the hardware does in user space, or it may cause corruption,
+ * even overlaps the kernel memory, be careful.
  *
  * */
 
@@ -74,7 +74,7 @@ int sys_close(struct trap *tf){
 int sys_read(struct trap *tf){
     int fd = tf->ebx;
     int cnt = tf->edx;
-    char *buf = (char*)tf->ecx; 
+    char *buf = (char*)tf->ecx;
 
     if(vm_verify(buf, cnt) < 0){
         syserr(EFAULT);
@@ -116,7 +116,7 @@ int sys_link(struct trap *tf){
 
 int sys_unlink(struct trap *tf){
     char *path = (char *) tf->ebx;
-    
+
     return do_unlink(path);
 }
 
@@ -150,7 +150,7 @@ int sys_fstat(struct trap *tf){
     int fd = (int)tf->ebx;
     struct stat *sbuf = (struct stat*)tf->ecx;
     struct file *fp;
-   
+
     if (fd<0 || fd>=NOFILE || cu->p_ofile[fd]==NULL) {
         syserr(EBADF);
         return -1;
@@ -161,7 +161,7 @@ int sys_fstat(struct trap *tf){
 
 /* int stat(char *path, struct stat *buf); */
 int sys_stat(struct trap *tf){
-    char *path = (char*)tf->ebx; 
+    char *path = (char*)tf->ebx;
     struct stat *sbuf = (struct stat*)tf->ecx;
     struct inode *ip;
 
@@ -176,7 +176,7 @@ int sys_stat(struct trap *tf){
     }
     return do_stat(ip, sbuf);
 }
- 
+
 /* int fcntl(int fd, int cmd, int arg); */
 int sys_fcntl(struct trap *tf){
     int fd = (int)tf->ebx;

--- a/src/kern/sys3.c
+++ b/src/kern/sys3.c
@@ -8,7 +8,7 @@
 /*
  * sys3.c
  * misc syscalls.
- * 
+ *
  * */
 
 int sys_nice(struct trap *tf){
@@ -56,13 +56,13 @@ int sys_setreuid(struct trap *tf){
     if (ruid > 0) {
         if ((cu->p_euid==ruid) || (old_ruid==ruid) || suser())
             cu->p_ruid = ruid;
-        else 
+        else
             return syserr(EPERM);
     }
     if (euid > 0) {
         if ((cu->p_euid==euid) || (old_ruid==euid) || suser())
             cu->p_euid = euid;
-        else 
+        else
             return syserr(EPERM);
     }
     return 0;
@@ -74,15 +74,15 @@ int sys_setregid(struct trap *tf){
     int egid = tf->ecx;
 
     if (rgid > 0) {
-        if ((cu->p_rgid==rgid) || suser()) 
+        if ((cu->p_rgid==rgid) || suser())
             cu->p_rgid = rgid;
-        else 
+        else
             return syserr(EPERM);
     }
     if (egid > 0) {
-        if (cu->p_egid==egid || cu->p_rgid==egid || suser()) 
+        if (cu->p_egid==egid || cu->p_rgid==egid || suser())
             cu->p_egid = egid;
-        else 
+        else
             return syserr(EPERM);
     }
     return 0;

--- a/src/kern/sys4.c
+++ b/src/kern/sys4.c
@@ -8,7 +8,7 @@
 #include <unistd.h>
 
 /*
- * sys4.c 
+ * sys4.c
  * syscalls on signal
  *
  * */
@@ -17,7 +17,7 @@
 int sys_kill(struct trap *tf){
     int pid = (int)tf->ebx;
     int sig = (int)tf->ecx;
-    
+
     return do_kill(pid, sig);
 }
 
@@ -45,7 +45,7 @@ int sys_sigaction(struct trap *tf){
     return do_sigaction(sig, sa, old_sa);
 }
 
-/* called on returning from the signal handler. 
+/* called on returning from the signal handler.
  * note: this syscall should NEVER be called directly.
  * */
 int sys_sigreturn(struct trap *tf){

--- a/src/kern/sysent.c
+++ b/src/kern/sysent.c
@@ -6,11 +6,11 @@
 #include <unistd.h>
 
 /*
- * sys.c 
+ * sys.c
  *
  * this file implies the common handler of all syscalls - do_syscall();
- * each syscall has got one syscall number, and a trap frame as parameters, 
- * eax is it's number, and ebx, ecx, edx, as parameters, return value 
+ * each syscall has got one syscall number, and a trap frame as parameters,
+ * eax is it's number, and ebx, ecx, edx, as parameters, return value
  * stores in eax.
  *
  * commonly returns -errno on error.
@@ -98,7 +98,7 @@ int do_syscall(struct trap *tf){
     }
     cu->p_error = 0;
     func = sys_routines[tf->eax];
-    
+
     if (func == NULL)
         func = &nosys;
     ret = (*func)(tf);

--- a/src/kern/timer.c
+++ b/src/kern/timer.c
@@ -27,7 +27,7 @@ uint cmos_time(){
     int year, month, mday, hour, min, sec;
     uint r;
     year  = cmos_read(RTC_CENTURY)*100 + cmos_read(RTC_YEAR) - 1970; // start at UNIX era
-    month = cmos_read(RTC_MONTH); 
+    month = cmos_read(RTC_MONTH);
     mday  = cmos_read(RTC_MDAY);
     hour  = cmos_read(RTC_HOUR);
     min   = cmos_read(RTC_MIN);

--- a/src/kern/trap.c
+++ b/src/kern/trap.c
@@ -12,7 +12,7 @@ struct idt_desc    idt_desc;
 
 // handlers to each int_no
 // which inited as 0
-static void* hwint_routines[256] = {0, }; 
+static void* hwint_routines[256] = {0, };
 
 static char *trap_str[] = {
     "Division By Zero",
@@ -55,12 +55,12 @@ static char *trap_str[] = {
 /* ------------------------------------------------------------ */
 
 /*
- * Remap the irq and initialize the IRQ mask. 
+ * Remap the irq and initialize the IRQ mask.
  *
- * note:If you do not remap irq, a Double Fault comes 
+ * note:If you do not remap irq, a Double Fault comes
  * along with every interrupt.
- * After initialization, register 0xA1 and 0x21 are the 
- * hi/lo bytes of irq mask, respectively. 
+ * After initialization, register 0xA1 and 0x21 are the
+ * hi/lo bytes of irq mask, respectively.
  * */
 void irq_init(){
     // hard coded, don't touch.
@@ -68,7 +68,7 @@ void irq_init(){
     outb(PIC2, 0x11);
     outb(PIC1+1, IRQ0); // offset 1, 0-7
     outb(PIC2+1, IRQ0+8); // offset 2, 7-15
-    outb(PIC1+1, 4); 
+    outb(PIC1+1, 4);
     outb(PIC2+1, 2);
     outb(PIC1+1, 0x01);
     outb(PIC2+1, 0x01);
@@ -119,13 +119,13 @@ void hwint_init(){
     int i;
     for(i=0;  i<32; i++)
         trap_gate(i, _hwint[i]);
-    for(i=32; i<48; i++) 
+    for(i=32; i<48; i++)
         intr_gate(i, _hwint[i]);
     syst_gate(0x03, _hwint[0x03]); // int3
     syst_gate(0x04, _hwint[0x04]); // overflow
     syst_gate(0x05, _hwint[0x05]); // bound
     syst_gate(0x80, _hwint[0x80]); // syscall
-    // Each handler handled in his file.  
+    // Each handler handled in his file.
     set_hwint(0x80, &do_syscall);      // in syscall.c
 }
 
@@ -138,13 +138,13 @@ void lidt(struct idt_desc idtd){
 /* ------------------------------------------------------------------- */
 
 /*
- * The comman handler for all IRQ request as a dispatcher. Each irq 
+ * The comman handler for all IRQ request as a dispatcher. Each irq
  * handler were held inside the array *hwint_routines*.
  *
  * note: While an IRQ were recieved, we have to notice the 8259 chip
- * that End of Interrupt via a PIC_EOI. If the IRQ came from the Master 
- * PIC, it is sufficient to issue this command only to the Master PIC; 
- * however if the IRQ came from the Slave PIC, it is necessary to issue 
+ * that End of Interrupt via a PIC_EOI. If the IRQ came from the Master
+ * PIC, it is sufficient to issue this command only to the Master PIC;
+ * however if the IRQ came from the Slave PIC, it is necessary to issue
  * the command to both PIC chips.
  * */
 void hwint_common(struct trap *tf) {
@@ -152,14 +152,14 @@ void hwint_common(struct trap *tf) {
 
     // save the current trap frame
     if ((tf->cs & 3)==RING3) {
-        cu->p_trap = tf; 
+        cu->p_trap = tf;
     }
     func = hwint_routines[tf->int_no];
     if (tf->int_no < 32) {
         // trap
         if (func)
             func(tf);
-        else 
+        else
             sigsend(cu->p_pid, SIGTRAP, 1);
     }
     else {
@@ -172,7 +172,7 @@ void hwint_common(struct trap *tf) {
     if (issig() && (cu->p_stat!=SZOMB) && ((tf->cs & 3)==RING3)) {
         psig();
     }
-    // on sheduling 
+    // on sheduling
     // if the re-schedule flag is set, make an task swtch.
     // and make sure only swtch on returning to user mode,
     // thus to keep the kernel nonpremtive.
@@ -211,7 +211,7 @@ void idt_init(){
     idt_desc.base = (uint)&idt;
     // init irq
     irq_init();
-    // load intr vectors and lidt 
+    // load intr vectors and lidt
     hwint_init();
     lidt(idt_desc);
 }

--- a/src/kern/wait.c
+++ b/src/kern/wait.c
@@ -12,17 +12,17 @@
 /*
  * The value of pid can be: (via `man waitpid`)
  *   < -1   wait for any child process whose process group ID is equal to the absolute value of pid.
- *   -1     wait for any child process.  
+ *   -1     wait for any child process.
  *   0      wait for any child process whose  process group ID  is equal to that of the calling process.
  *   > 0    wait for the child whose process ID is equal to the value of pid.
  *
- * opt: 
- *   WNOHANG : return immediately if no child exited.  
+ * opt:
+ *   WNOHANG : return immediately if no child exited.
  *
 */
 int do_waitpid(int pid, int *stat, int opt){
     struct proc *p;
-    uint nr; 
+    uint nr;
 
     if (vm_verify(stat, sizeof(int)) < 0){
         syserr(EFAULT);
@@ -33,19 +33,19 @@ _repeat:
     for(nr=1; nr<NPROC; nr++){
         if ((p=proc[nr]) && p!=cu) {
             if (pid < -1) {
-                if (p->p_ppid!=cu->p_pid || p->p_pgrp!=cu->p_pid) 
+                if (p->p_ppid!=cu->p_pid || p->p_pgrp!=cu->p_pid)
                     continue;
             }
             else if (pid == -1) {
-                if (p->p_ppid!=cu->p_pid) 
+                if (p->p_ppid!=cu->p_pid)
                     continue;
             }
             else if (pid == 0) {
-                if (p->p_ppid!=cu->p_pid || p->p_pgrp!=cu->p_pgrp) 
+                if (p->p_ppid!=cu->p_pid || p->p_pgrp!=cu->p_pgrp)
                     continue;
             }
             else if (pid > 0) {
-                if (p->p_ppid!=cu->p_pid || p->p_pid!=pid) 
+                if (p->p_ppid!=cu->p_pid || p->p_pid!=pid)
                     continue;
             }
             // on found

--- a/src/lib/string.c
+++ b/src/lib/string.c
@@ -43,22 +43,22 @@ int strnlen(char *str, unsigned int len){
 
 char* strcpy(char *dst, const char *src) {
 	char *tmp = dst;
-    while ((*dst++ = *src++)); 
+    while ((*dst++ = *src++));
 	return tmp;
 }
 
 char *strncpy(char *dst, const char *src, unsigned int cnt) {
     char *tmp = dst;
-    while (cnt && (*dst++ = *src++)) 
+    while (cnt && (*dst++ = *src++))
         cnt--;
-    if (cnt > 0) 
-        while (--cnt) 
+    if (cnt > 0)
+        while (--cnt)
             *dst++ = '\0';
     return tmp;
 }
 
-/* 
- * note that '\0' is considered to be part of the string. 
+/*
+ * note that '\0' is considered to be part of the string.
  * returns not a number but a pointer.
  * */
 char* strchr(const char *str, int c){
@@ -69,7 +69,7 @@ char* strchr(const char *str, int c){
             return tmp;
         }
     }
-    if (*tmp == (char)c) 
+    if (*tmp == (char)c)
         return tmp;
     return NULL;
 }
@@ -87,7 +87,7 @@ char* strrchr(const char *str, int c){
     return NULL;
 }
 
-/* 
+/*
  * TODO: debug all these.
  * */
 int strcmp(char *s1, char *s2){
@@ -105,6 +105,6 @@ int strncmp(char *s1, char* s2, unsigned int n) {
             return (*(unsigned char*)s1 - *(unsigned char*)(s2-1));
         if (*s1++ == 0)
             break;
-    } 
+    }
     return 0;
 }

--- a/src/mm/malloc.c
+++ b/src/mm/malloc.c
@@ -18,7 +18,7 @@
  * */
 
 /*
- * the bucket table, each slot got a different 2-powered size. 
+ * the bucket table, each slot got a different 2-powered size.
  * 1 << 3 == 32,  1 << 12 == 0x1000
  * */
 struct bucket bktab[] = {
@@ -37,7 +37,7 @@ struct bucket bkfreelist = {0, };
 /* ---------------------------------------------------------- */
 
 inline int bkslot(int size){
-    int n,i; 
+    int n,i;
 
     if (size <= 0)
         return -1;
@@ -46,13 +46,13 @@ inline int bkslot(int size){
     while((n <<= 1)<=4096) {
         if (size <= n){
             return i;
-        } 
+        }
         i++;
     }
     return -1;
 }
 
-/* 
+/*
  * Allocate one bucket. All free buckets are cached in one free list,
  * if no free bucket, allocate one page and divide it into buckets.
  * */
@@ -112,7 +112,7 @@ int bkinit(struct bucket *bk, int size){
 
 /* -------------------------------------------------------- */
 
-/* 
+/*
  * kmalloc().
  * one page size is special considered, for no need to arrange
  * any bucket. which symmeties in kfree.
@@ -127,7 +127,7 @@ void* kmalloc(uint size){
     if (sn < 0) {
         panic("kmalloc(): bad size");
     }
-    
+
     bk = bh = &bktab[sn];
     size = bh->bk_size;
     // special case for one page size
@@ -155,7 +155,7 @@ _find:
 }
 
 /*
- * 
+ *
  * */
 int kfree(void* addr, uint size){
     int sn;

--- a/src/mm/pgfault.c
+++ b/src/mm/pgfault.c
@@ -58,12 +58,12 @@ void do_no_page(uint vaddr){
     panic("do_no_page()");
 }
 
-/* 
+/*
  * the handler of the read-only protection. here is the 'copy' action
  * of the implemtion of copy-on-write.
  * If this one is the last one who did the write, just mark the page as
  * write-able.
- * else allocate one page and associate inside the page table. 
+ * else allocate one page and associate inside the page table.
  * */
 void do_wp_page(uint vaddr){
     struct vma *vp;
@@ -117,7 +117,7 @@ int do_pgfault(struct trap *tf){
     if (tf->err_code & PFE_U) {
         sigsend(cu->p_pid, SIGSEGV, 1);
     }
-    
+
     return 0;
 }
 

--- a/src/mm/pm.c
+++ b/src/mm/pm.c
@@ -16,14 +16,14 @@
 #include <file.h>
 
 /* pm.c
- * this file implies some routines on the allocation, free, and modification of 
+ * this file implies some routines on the allocation, free, and modification of
  * physical pages(.aka page frames).
  * */
 
 
 /*
  * the map for page frames. Each physical page is associated with one reference
- * count, and it's free on 0. Only 0 can be allocated via pgalloc().  
+ * count, and it's free on 0. Only 0 can be allocated via pgalloc().
  * Reference count is increased on a fork.
  *
  * */
@@ -38,10 +38,10 @@ struct page* pgfind(uint pn){
     return &coremap[pn];
 }
 
-/* 
+/*
  * allocate an free physical page. (always success)
  * get the head of the freelist, remove it and increase the refcount.
- * */ 
+ * */
 struct page* pgalloc(){
     struct page *pp;
 
@@ -49,7 +49,7 @@ struct page* pgalloc(){
         panic("no free page.\n");
         return NULL;
     }
-    
+
     cli();
     pp = pgfreelist.pg_next;
     pgfreelist.pg_next = pp->pg_next;
@@ -60,7 +60,7 @@ struct page* pgalloc(){
 
 /*
  * free a physical page. decrease the reference count and put it back
- * to the freelist. 
+ * to the freelist.
  */
 int pgfree(struct page *pp){
     if (pp->pg_count==0) {
@@ -129,7 +129,7 @@ int pm_init(){
 }
 
 /* Map the top 128mb virtual memory as physical memory. Initiliaze
- * the page-level allocator, setup the fault handler, enable paging 
+ * the page-level allocator, setup the fault handler, enable paging
  * and misc.
  * */
 void mm_init(){

--- a/src/mm/pte.c
+++ b/src/mm/pte.c
@@ -17,19 +17,19 @@
 /* pte.c
  * some operations on page tables.
  * note: PGD and page tables are all one page size, allocated via the routine kmalloc().
- * 
- * note: on *Copy-On-Write*, both parent and child process will be marked 
- * write-protected, and increase the reference count of each shared page 
- * frame. 
- * On write-proctection fault occured, if the reference count greater 
- * than 1, allocate one page frame, attach it to where it deserves and 
+ *
+ * note: on *Copy-On-Write*, both parent and child process will be marked
+ * write-protected, and increase the reference count of each shared page
+ * frame.
+ * On write-proctection fault occured, if the reference count greater
+ * than 1, allocate one page frame, attach it to where it deserves and
  * decrease the reference count;
  * If the reference count equals 1,  just mark it Writeable.
  *
  * */
 
 /*
- * the proc[0]'s page directory, as initialized, it will map the top 128mb virtual memory 
+ * the proc[0]'s page directory, as initialized, it will map the top 128mb virtual memory
  * as physical memory, by the 4mb big page tables.
  * */
 struct pde pgd0[1024] __attribute__((aligned(4096)));
@@ -37,12 +37,12 @@ struct pde pgd0[1024] __attribute__((aligned(4096)));
 /* --------------------------------------------------------- */
 
 /*
- * given the current proc's page directory, find the pte where 
+ * given the current proc's page directory, find the pte where
  * the virtual address lied in. If the 'creat' parameter is set,
  * allocate a page as middle page table and always success.
  * */
 struct pte* find_pte(struct pde *pgd, uint vaddr, uint creat){
-    struct pde *pde; 
+    struct pde *pde;
     struct pte *pt;
     struct page *pg;
 
@@ -84,10 +84,10 @@ int pgd_init(struct pde *pgd){
     return 0;
 }
 
-/* copy the page tables, and set both pte's flag. 
- * note: on Copy On Write, both parent and child process will be marked 
- * write-protected, and increase the reference count of each shared physical 
- * page. 
+/* copy the page tables, and set both pte's flag.
+ * note: on Copy On Write, both parent and child process will be marked
+ * write-protected, and increase the reference count of each shared physical
+ * page.
  * */
 int pt_copy(struct pde *npgd, struct pde *opgd){
     struct pde *opde, *npde;

--- a/src/mm/vm.c
+++ b/src/mm/vm.c
@@ -48,9 +48,9 @@ int vm_clone(struct vm *to){
     return 0;
 }
 
-/* free all the pages used in this process, deallocate all the page tables, 
- * this routine is called on freeing one task in do_exit(), or overlapping 
- * a proc's address space on do_exec() is being called. 
+/* free all the pages used in this process, deallocate all the page tables,
+ * this routine is called on freeing one task in do_exit(), or overlapping
+ * a proc's address space on do_exec() is being called.
  * note: this routine will *NOT* free the pgd.
  * */
 int vm_clear(struct vm *vm){
@@ -81,7 +81,7 @@ int vm_renew(struct vm *vm, struct ahead *ah, struct inode *ip){
     text = ah->a_entry - sizeof(struct ahead);
     data = text + ah->a_tsize;
     bss  = data + ah->a_dsize;
-    heap = bss  + ah->a_bsize; 
+    heap = bss  + ah->a_bsize;
     //
     pgd_init(vm->vm_pgd);
     vm->vm_entry = ah->a_entry;
@@ -93,24 +93,24 @@ int vm_renew(struct vm *vm, struct ahead *ah, struct inode *ip){
     return 0;
 }
 
-/* Have a check of virtual memory area on getting a user space 
- * pointer, on writing a write protected page, x86 do not raise 
- * a page fault in ring0, so simulate a write only access as 
+/* Have a check of virtual memory area on getting a user space
+ * pointer, on writing a write protected page, x86 do not raise
+ * a page fault in ring0, so simulate a write only access as
  * what mmu does if nessary.
  *
- * note:  
+ * note:
  *   be aware that do NOT touch the memory in the second argument
  *   like `vm_verify(path, strlen(path) + 1)`, which is a bug
  *
- * note2: 
- *   use this routine only before reading and writing the 
+ * note2:
+ *   use this routine only before reading and writing the
  *   user memory.
  * */
 int vm_verify(void *vaddr, uint size){
     struct pte *pte;
     uint page;
     uint addr = (uint)vaddr;
-    
+
     if (addr<KMEM_END || size<0) {
         return -1;
     }

--- a/usr/cat.c
+++ b/usr/cat.c
@@ -10,7 +10,7 @@ int cat(char *pathp){
     int n;
 
     fd = open(pathp, O_RDONLY, 0);
-    if (fd < 0) 
+    if (fd < 0)
         return -1;
 
     while((n = read(fd, buf, 32)) > 0){

--- a/usr/libsys/printf.c
+++ b/usr/libsys/printf.c
@@ -18,14 +18,14 @@ void printn(uint n, uint b){
     static char *ntab = "0123456789ABCDEF";
     uint a, m;
     if (a = n / b){
-        printn(a, b);  
+        printn(a, b);
     }
     m = n % b;
     putch( ntab[m] );
 }
 
 /* a simpler printk
- * refer to unix v6 
+ * refer to unix v6
  * */
 void printf(char *fmt, ...){
     char c, *s;

--- a/usr/libsys/string.c
+++ b/usr/libsys/string.c
@@ -45,16 +45,16 @@ int strnlen(char *str, unsigned int len){
 
 char* strcpy(char *dst, const char *src) {
 	char *tmp = dst;
-    while (*dst++ = *src++); 
+    while (*dst++ = *src++);
 	return tmp;
 }
 
 char *strncpy(char *dst, const char *src, unsigned int cnt) {
     char *tmp = dst;
-    while (cnt && (*dst++ = *src++)) 
+    while (cnt && (*dst++ = *src++))
         cnt--;
-    if (cnt > 0) 
-        while (--cnt) 
+    if (cnt > 0)
+        while (--cnt)
             *dst++ = '\0';
     return tmp;
 }
@@ -68,7 +68,7 @@ char *strcat(char *dst, const char *src){
 
 char *strncat(char *dst, const char *src, unsigned int n){
     char *tmp = dst;
-    if (n==0) 
+    if (n==0)
         return dst;
     for(;*tmp; tmp++);
     while (*tmp++ = *src++) {
@@ -80,8 +80,8 @@ char *strncat(char *dst, const char *src, unsigned int n){
     return dst;
 }
 
-/* 
- * note that '\0' is considered to be part of the string. 
+/*
+ * note that '\0' is considered to be part of the string.
  * returns not a number but a pointer.
  * */
 char* strchr(const char *str, int c){
@@ -90,7 +90,7 @@ char* strchr(const char *str, int c){
             return str;
         }
     }
-    if (*str == (char)c) 
+    if (*str == (char)c)
         return str;
     return NULL;
 }
@@ -108,7 +108,7 @@ char* strrchr(const char *str, int c){
     return NULL;
 }
 
-/* 
+/*
  * TODO: debug all these.
  * */
 int strcmp(char *s1, char *s2){
@@ -126,6 +126,6 @@ int strncmp(char *s1, char* s2, unsigned int n) {
             return (*(unsigned char*)s1 - *(unsigned char*)(s2-1));
         if (*s1++ == 0)
             break;
-    } 
+    }
     return 0;
 }

--- a/usr/ls.c
+++ b/usr/ls.c
@@ -12,7 +12,7 @@ int ls(char *pathp){
 
     if (pathp==NULL)
         strcpy(pathbuf, ".");
-    else 
+    else
         strncpy(pathbuf, pathp, 1024);
     //
     fd = open(pathbuf, O_RDONLY, 0);
@@ -31,7 +31,7 @@ int ls(char *pathp){
 int main(int argc, char **argv){
     int i = 0;
 
-    if (argc==1) 
+    if (argc==1)
         ls(NULL);
     else{
         for(i=1; i<argc; i++)

--- a/usr/sh.c
+++ b/usr/sh.c
@@ -21,9 +21,9 @@ int lparse(char *lbuf) {
     argc = 0;
     lp = lbuf;
     while((c=*lp++) && lp<&linebuf[LINEBUFSIZ]) {
-        if (c == ' ') 
+        if (c == ' ')
             continue;
-        argvbuf[argc] = lp-1; 
+        argvbuf[argc] = lp-1;
         argc++;
         while(*lp++ != ' ');
     }
@@ -37,7 +37,7 @@ int lparse(char *lbuf) {
 }
 
 int main(int argc, char **argv){
-    int r,fd, i, cnt, ret; 
+    int r,fd, i, cnt, ret;
     struct sigaction sa;
 
     setpgrp();


### PR DESCRIPTION
The following command is used to accomplish this:

```
git ls-files | xargs sed -i '' -e's/[[:space:]]*$//'
```

the sed here is BSD version (I'm using a Mac), but it is supposed to work well with
GNU version.

I think getting rid of trailing whitespace is a good practice and it is very easy to be done since many text editors has this built-in feature.
